### PR TITLE
Fix build script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ chmod +x ./build-s3-dist.sh \n
 
 * Deploy the distributable to an Amazon S3 bucket in your account. _Note:_ you must have the AWS Command Line Interface installed.
 ```
-aws s3 cp ./dist/ s3://my-bucket-name-<aws_region>/iot-device-simulator/<my-version>/ --recursive --acl bucket-owner-full-control --profile aws-cred-profile-name \n
+aws s3 cp ./regional-s3-assets/ s3://my-bucket-name-<aws_region>/iot-device-simulator/<my-version>/ --recursive --acl bucket-owner-full-control --profile <your-profile> \n
 ```
 
 * Get the link of the iot-device-simulator.template uploaded to your Amazon S3 bucket.

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -15,9 +15,9 @@
 #  - version-code: version of the package
 
 # Check to see if input has been provided:
-if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
-    echo "Please provide the base source bucket name, open-source bucket name, trademark approved solution name and version where the lambda code will eventually reside."
-    echo "For example: ./build-s3-dist.sh solutions solutions-github trademarked-solution-name v1.0.0"
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+    echo "Please provide the base source bucket name, trademark approved solution name and version where the lambda code will eventually reside."
+    echo "For example: ./build-s3-dist.sh solutions trademarked-solution-name v1.0.0"
     exit 1
 fi
 
@@ -26,6 +26,9 @@ template_dir="$PWD"
 template_dist_dir="$template_dir/global-s3-assets"
 build_dist_dir="$template_dir/regional-s3-assets"
 source_dir="$template_dir/../source"
+input_bucket_name="$1"
+input_solution_name="$2"
+input_version_number="$3"
 
 echo "------------------------------------------------------------------------------"
 echo "[Init] Clean old dist folders"
@@ -49,14 +52,14 @@ echo "--------------------------------------------------------------------------
 echo "cp $template_dir/iot-device-simulator.yaml $template_dist_dir/iot-device-simulator.template"
 cp $template_dir/iot-device-simulator.yaml $template_dist_dir/iot-device-simulator.template
 
-echo "Updating code source bucket in template with $1"
-replace="s/%%BUCKET_NAME%%/$1/g"
+echo "Updating code source bucket in template with $input_bucket_name"
+replace="s/%%BUCKET_NAME%%/$input_bucket_name/g"
 echo "sed -i '' -e $replace $template_dist_dir/iot-device-simulator.template"
 sed -i '' -e $replace $template_dist_dir/iot-device-simulator.template
-replace="s/%%VERSION%%/$4/g"
+replace="s/%%VERSION%%/$input_version_number/g"
 echo "sed -i '' -e $replace $template_dist_dir/iot-device-simulator.template"
 sed -i '' -e $replace $template_dist_dir/iot-device-simulator.template
-replace="s/%%SOLUTION_NAME%%/$3/g"
+replace="s/%%SOLUTION_NAME%%/$input_solution_name/g"
 echo "sed -i '' -e $replace $template_dist_dir/iot-device-simulator.template"
 sed -i '' -e $replace $template_dist_dir/iot-device-simulator.template
 


### PR DESCRIPTION
*Description of changes:*

The `build-s3-dist.sh` script was expecting 4 input parameters while only 3 were used inside the script (the second parameter was never used in the script).

The doc was referring to `./dist` folder that is not generated by the script and I guess the correct value is `./regional-s3-assets` (where all the code, lambda are placed by the script)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
