### PR TITLE
Replace deprecated 'uuid/v4' requires

### DIFF
--- a/source/simulator/lib/modules/auto/vehicle/vehicle.js
+++ b/source/simulator/lib/modules/auto/vehicle/vehicle.js
@@ -7,7 +7,7 @@ const randomstring = require('randomstring');
 const shortid = require('shortid');
 const moment = require('moment');
 const _ = require('underscore');
-const uuidV4 = require('uuid/v4');
+const { v4: uuidV4 } = require('uuid');
 
 /**
  *

--- a/source/simulator/lib/modules/general/generator.js
+++ b/source/simulator/lib/modules/general/generator.js
@@ -23,7 +23,7 @@
 const random = require('generate-random-data');
 const moment = require('moment');
 const shortid = require('shortid');
-const uuidV4 = require('uuid/v4');
+const { v4: uuidV4 } = require('uuid');
 const validate = require('validate.js');
 const grp = require('generate-random-points');
 


### PR DESCRIPTION
The `uuid` package has [dropped support for deep requires](https://www.npmjs.com/package/uuid#deep-requires-now-deprecated) in v8. As a result, building the project or executing `run-unit-tests.sh` on a fresh clone fails with import errors. This PR updates the depreciated `const uuidV4 = require('uuid/v4')` statements with the recommended `const { v4: uuidV4 } = require('uuid')` form. 

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
