### PR TITLE
Instead of email, user ID works. (#2)

### DIFF
--- a/source/console/src/app/public/auth/newpassword/newpassword.html
+++ b/source/console/src/app/public/auth/newpassword/newpassword.html
@@ -42,7 +42,7 @@
                 <p>This is your first time logging in. You must set a new password.</p>
                 <form id="signin-form" class="form" action="#">
                     <div class="form-group">
-                        <input type="text" class="form-control" placeholder="Your email" style="" [(ngModel)]="registrationUser.email" [ngModelOptions]="{standalone: true}">
+                        <input type="text" class="form-control" placeholder="Your user ID" style="" [(ngModel)]="registrationUser.email" [ngModelOptions]="{standalone: true}">
                     </div>
                     <div class="form-group">
                         <input type="password" class="form-control" placeholder="Your existing password" style="" [(ngModel)]="registrationUser.existingPassword" [ngModelOptions]="{standalone: true}">


### PR DESCRIPTION
Instead of email, user ID works.
In order to prevent user failure, this bypass should be applied and later resolved internally.
https://github.com/awslabs/iot-device-simulator/issues/2#issuecomment-781811566

*Issue #, if available:*
#2 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
